### PR TITLE
fix(sessions): guard registerSession upsert against completed rows

### DIFF
--- a/src/services/sessionStateManager.js
+++ b/src/services/sessionStateManager.js
@@ -26,11 +26,22 @@ async function registerSession(userId, sessionId, sessionNumber, tenantId) {
   const tid = tenantId || _currentTenantId;
   const t = tenantInsert(tid, 4);
 
+  // Guard: ON CONFLICT must NEVER overwrite a completed row. completed_at IS NOT NULL
+  // means a prior session attempt completed normally and that row is forensic data.
+  // If the conflict matches a completed row, the UPDATE silently no-ops (every column
+  // wrapped in CASE returns the existing value), preserving the historical record.
+  // Caller can detect via xmax = 0 (no row updated) if it needs to differentiate;
+  // current callers don't, and the in-memory return value (sessionKey) is still valid
+  // for the caller's own state tracking.
   await pool.query(`
     INSERT INTO session_completions (user_id, session_number, session_key, session_active, session_state, arrival_started_at${t.columns}, created_at)
     VALUES ($1, $2, $3, true, $4, NOW()${t.values}, NOW())
     ON CONFLICT (user_id, session_number)
-    DO UPDATE SET session_key = $3, session_active = true, session_state = $4, arrival_started_at = NOW()
+    DO UPDATE SET
+      session_key = CASE WHEN session_completions.completed_at IS NULL THEN $3 ELSE session_completions.session_key END,
+      session_active = CASE WHEN session_completions.completed_at IS NULL THEN true ELSE session_completions.session_active END,
+      session_state = CASE WHEN session_completions.completed_at IS NULL THEN $4 ELSE session_completions.session_state END,
+      arrival_started_at = CASE WHEN session_completions.completed_at IS NULL THEN NOW() ELSE session_completions.arrival_started_at END
   `, [userId, sessionNumber, sessionKey, JSON.stringify({
     phase: 'arrival',
     paused: false,


### PR DESCRIPTION
registerSession's ON CONFLICT (user_id, session_number) DO UPDATE was unconditionally setting session_active=true and arrival_started_at=NOW() on the conflicting row. When that row was already completed (completed_at populated, exit_type='normal'), the upsert silently overwrote two columns on a forensic historical record.

Symptom observed in prod 2026-04-30: opening Session 11 in the frontend flipped row id=1 (Session 1, completed 2026-03-30) to session_active=true and stamped arrival_started_at = today. completed_at, session_number, exit_type were untouched (because the UPDATE only sets four columns).

This is the same class of bug Blocker 1 (commit e0dbdd4) fixed in v8Routes.js /api/fr/progress — that patch added a CASE-WHEN guard on session_active and completed_at. The guard never propagated here.

Fix: every column the DO UPDATE sets is now CASE-guarded on session_completions.completed_at IS NULL. A completed row hit by the conflict path is left untouched. In-progress rows continue to upsert normally.

Side effect: if a user genuinely re-attempts a completed session, this path silently no-ops and the in-memory sessionKey will be returned but not bound to a fresh DB row. Revisit semantics aren't solved here — that's a separate design question (per CLAUDE.md "Spiral Depth Model" the schema would need a multi-attempt-per-(user,session) constraint). This patch is data-integrity-first; revisit handling is a follow-up.

No schema change. No migration. Reversible by reverting this commit.

Audit-gate: paste-back review pending. PR opened, not merged.