### PR TITLE
fix(embedded): pick URL-requested session via cross-IIFE event listener

### DIFF
--- a/public/index_v8.html
+++ b/public/index_v8.html
@@ -2622,7 +2622,7 @@ var Integration = (function() {
     var urlParams=new URLSearchParams(window.location.search);_isEmbedded=urlParams.get('embedded')==='true';
     if(_isEmbedded)_initEmbeddedMode();_setApiStatus('connecting');
   }
-  function _initEmbeddedMode(){console.log('[EMBEDDED] Mode active');window.parent.postMessage({type:'iframe_ready'},'*');var readyInterval=setInterval(function(){if(_embeddedAuthReceived){clearInterval(readyInterval);return;}window.parent.postMessage({type:'iframe_ready'},'*');},500);window.addEventListener('message',function(event){var data=event.data||{};if(data.type!=='auth')return;if(!data.token){console.warn('[EMBEDDED] Auth message arrived without token — staying in harness mode');_embeddedAuthReceived=true;return;}_embeddedAuthReceived=true;if(_abi)_abi.token=data.token;localStorage.setItem('ascen_jwt',data.token);if(data.apiKey&&_abi)_abi.apiKey=data.apiKey;try{var payload=JSON.parse(atob(data.token.split('.')[1]));var _newUserId=payload.userId||payload.sub||payload.id||_userId;if(_newUserId!==_userId&&_userId&&typeof BioBridge!=='undefined')BioBridge.destroyUser(_userId);_userId=_newUserId;localStorage.setItem('ascen_uid',String(_userId));}catch(e){}console.log('[EMBEDDED] Auth received | userId:',_userId);loadSessions().then(function(sessions){if(!sessions||!sessions.length)return;var urlP=new URLSearchParams(window.location.search);var reqSess=parseInt(urlP.get('session'),10);var reqTrack=urlP.get('track');var validTracks=['foundation','fr_apprentice','coupling','capacity'];var pool=(reqTrack&&validTracks.indexOf(reqTrack)>=0)?sessions.filter(function(s){return s.track===reqTrack}):sessions.filter(function(s){return s.track==='foundation'});if(!pool.length)pool=sessions;var firstSession;if(reqSess&&reqSess>0){firstSession=pool.find(function(s){return s.session_number===reqSess});if(!firstSession){console.warn('[EMBEDDED] Requested session '+reqSess+' not found, falling back');firstSession=pool.find(function(s){return s.session_number===1})||pool[0];}else{console.log('[EMBEDDED] URL override: session='+reqSess+(reqTrack?' track='+reqTrack:''));}}else{firstSession=pool.find(function(s){return s.session_number===1})||pool[0];}if(!firstSession)return;if(!firstSession.session_number&&firstSession.session_number!==0)firstSession.session_number=1;applySession(firstSession);});});}
+  function _initEmbeddedMode(){console.log('[EMBEDDED] Mode active');window.parent.postMessage({type:'iframe_ready'},'*');var readyInterval=setInterval(function(){if(_embeddedAuthReceived){clearInterval(readyInterval);return;}window.parent.postMessage({type:'iframe_ready'},'*');},500);window.addEventListener('message',function(event){var data=event.data||{};if(data.type!=='auth')return;if(!data.token){console.warn('[EMBEDDED] Auth message arrived without token — staying in harness mode');_embeddedAuthReceived=true;return;}_embeddedAuthReceived=true;if(_abi)_abi.token=data.token;localStorage.setItem('ascen_jwt',data.token);if(data.apiKey&&_abi)_abi.apiKey=data.apiKey;try{var payload=JSON.parse(atob(data.token.split('.')[1]));var _newUserId=payload.userId||payload.sub||payload.id||_userId;if(_newUserId!==_userId&&_userId&&typeof BioBridge!=='undefined')BioBridge.destroyUser(_userId);_userId=_newUserId;localStorage.setItem('ascen_uid',String(_userId));}catch(e){}console.log('[EMBEDDED] Auth received | userId:',_userId);loadSessions();});}
   function _notifyParentComplete(sessionNumber){if(_isEmbedded)window.parent.postMessage({type:'session_complete',data:{session_number:sessionNumber}},'*');}
   function _notifyParentExit(){if(_isEmbedded)window.parent.postMessage({type:'session_exit'},'*');}
   function isEmbedded(){return _isEmbedded}
@@ -3158,6 +3158,39 @@ var BiofeedbackSound = (function() {
   // === LOAD SESSIONS ===
   if (Integration.isEmbedded()) {
     console.log('[ASCEN] Embedded mode — waiting for auth...');
+    // Single-fire listener that picks the URL-requested session once
+    // Integration's auth handler fetches the list. applySession lives in this
+    // IIFE's scope (line 3114). _initEmbeddedMode lives in Integration's IIFE
+    // and cannot see applySession directly. We cross the boundary via the
+    // existing 'sessionsLoaded' event Integration emits from loadSessions().
+    var _embeddedOff = Integration.on('sessionsLoaded', function(payload) {
+      if (_embeddedOff) { _embeddedOff(); _embeddedOff = null; }
+      var sessions = payload && payload.sessions;
+      if (!sessions || !sessions.length) return;
+      var urlP = new URLSearchParams(window.location.search);
+      var reqSess = parseInt(urlP.get('session'), 10);
+      var reqTrack = urlP.get('track');
+      var validTracks = ['foundation','fr_apprentice','coupling','capacity'];
+      var pool = (reqTrack && validTracks.indexOf(reqTrack) >= 0)
+        ? sessions.filter(function(s){return s.track===reqTrack})
+        : sessions.filter(function(s){return s.track==='foundation'});
+      if (!pool.length) pool = sessions;
+      var firstSession;
+      if (reqSess && reqSess > 0) {
+        firstSession = pool.find(function(s){return s.session_number===reqSess});
+        if (!firstSession) {
+          console.warn('[EMBEDDED] Requested session '+reqSess+' not found, falling back');
+          firstSession = pool.find(function(s){return s.session_number===1}) || pool[0];
+        } else {
+          console.log('[EMBEDDED] URL override: session='+reqSess+(reqTrack?' track='+reqTrack:''));
+        }
+      } else {
+        firstSession = pool.find(function(s){return s.session_number===1}) || pool[0];
+      }
+      if (!firstSession) return;
+      if (!firstSession.session_number && firstSession.session_number !== 0) firstSession.session_number = 1;
+      applySession(firstSession);
+    });
   } else {
     var sessions = await Integration.loadSessions();
     if (sessions && sessions.length > 0) {

--- a/public/index_v8_production.html
+++ b/public/index_v8_production.html
@@ -2622,7 +2622,7 @@ var Integration = (function() {
     var urlParams=new URLSearchParams(window.location.search);_isEmbedded=urlParams.get('embedded')==='true';
     if(_isEmbedded)_initEmbeddedMode();_setApiStatus('connecting');
   }
-  function _initEmbeddedMode(){console.log('[EMBEDDED] Mode active');window.parent.postMessage({type:'iframe_ready'},'*');var readyInterval=setInterval(function(){if(_embeddedAuthReceived){clearInterval(readyInterval);return;}window.parent.postMessage({type:'iframe_ready'},'*');},500);window.addEventListener('message',function(event){var data=event.data||{};if(data.type!=='auth')return;if(!data.token){console.warn('[EMBEDDED] Auth message arrived without token — staying in harness mode');_embeddedAuthReceived=true;return;}_embeddedAuthReceived=true;if(_abi)_abi.token=data.token;localStorage.setItem('ascen_jwt',data.token);if(data.apiKey&&_abi)_abi.apiKey=data.apiKey;try{var payload=JSON.parse(atob(data.token.split('.')[1]));var _newUserId=payload.userId||payload.sub||payload.id||_userId;if(_newUserId!==_userId&&_userId&&typeof BioBridge!=='undefined')BioBridge.destroyUser(_userId);_userId=_newUserId;localStorage.setItem('ascen_uid',String(_userId));}catch(e){}console.log('[EMBEDDED] Auth received | userId:',_userId);loadSessions().then(function(sessions){if(!sessions||!sessions.length)return;var urlP=new URLSearchParams(window.location.search);var reqSess=parseInt(urlP.get('session'),10);var reqTrack=urlP.get('track');var validTracks=['foundation','fr_apprentice','coupling','capacity'];var pool=(reqTrack&&validTracks.indexOf(reqTrack)>=0)?sessions.filter(function(s){return s.track===reqTrack}):sessions.filter(function(s){return s.track==='foundation'});if(!pool.length)pool=sessions;var firstSession;if(reqSess&&reqSess>0){firstSession=pool.find(function(s){return s.session_number===reqSess});if(!firstSession){console.warn('[EMBEDDED] Requested session '+reqSess+' not found, falling back');firstSession=pool.find(function(s){return s.session_number===1})||pool[0];}else{console.log('[EMBEDDED] URL override: session='+reqSess+(reqTrack?' track='+reqTrack:''));}}else{firstSession=pool.find(function(s){return s.session_number===1})||pool[0];}if(!firstSession)return;if(!firstSession.session_number&&firstSession.session_number!==0)firstSession.session_number=1;applySession(firstSession);});});}
+  function _initEmbeddedMode(){console.log('[EMBEDDED] Mode active');window.parent.postMessage({type:'iframe_ready'},'*');var readyInterval=setInterval(function(){if(_embeddedAuthReceived){clearInterval(readyInterval);return;}window.parent.postMessage({type:'iframe_ready'},'*');},500);window.addEventListener('message',function(event){var data=event.data||{};if(data.type!=='auth')return;if(!data.token){console.warn('[EMBEDDED] Auth message arrived without token — staying in harness mode');_embeddedAuthReceived=true;return;}_embeddedAuthReceived=true;if(_abi)_abi.token=data.token;localStorage.setItem('ascen_jwt',data.token);if(data.apiKey&&_abi)_abi.apiKey=data.apiKey;try{var payload=JSON.parse(atob(data.token.split('.')[1]));var _newUserId=payload.userId||payload.sub||payload.id||_userId;if(_newUserId!==_userId&&_userId&&typeof BioBridge!=='undefined')BioBridge.destroyUser(_userId);_userId=_newUserId;localStorage.setItem('ascen_uid',String(_userId));}catch(e){}console.log('[EMBEDDED] Auth received | userId:',_userId);loadSessions();});}
   function _notifyParentComplete(sessionNumber){if(_isEmbedded)window.parent.postMessage({type:'session_complete',data:{session_number:sessionNumber}},'*');}
   function _notifyParentExit(){if(_isEmbedded)window.parent.postMessage({type:'session_exit'},'*');}
   function isEmbedded(){return _isEmbedded}
@@ -3158,6 +3158,39 @@ var BiofeedbackSound = (function() {
   // === LOAD SESSIONS ===
   if (Integration.isEmbedded()) {
     console.log('[ASCEN] Embedded mode — waiting for auth...');
+    // Single-fire listener that picks the URL-requested session once
+    // Integration's auth handler fetches the list. applySession lives in this
+    // IIFE's scope (line 3114). _initEmbeddedMode lives in Integration's IIFE
+    // and cannot see applySession directly. We cross the boundary via the
+    // existing 'sessionsLoaded' event Integration emits from loadSessions().
+    var _embeddedOff = Integration.on('sessionsLoaded', function(payload) {
+      if (_embeddedOff) { _embeddedOff(); _embeddedOff = null; }
+      var sessions = payload && payload.sessions;
+      if (!sessions || !sessions.length) return;
+      var urlP = new URLSearchParams(window.location.search);
+      var reqSess = parseInt(urlP.get('session'), 10);
+      var reqTrack = urlP.get('track');
+      var validTracks = ['foundation','fr_apprentice','coupling','capacity'];
+      var pool = (reqTrack && validTracks.indexOf(reqTrack) >= 0)
+        ? sessions.filter(function(s){return s.track===reqTrack})
+        : sessions.filter(function(s){return s.track==='foundation'});
+      if (!pool.length) pool = sessions;
+      var firstSession;
+      if (reqSess && reqSess > 0) {
+        firstSession = pool.find(function(s){return s.session_number===reqSess});
+        if (!firstSession) {
+          console.warn('[EMBEDDED] Requested session '+reqSess+' not found, falling back');
+          firstSession = pool.find(function(s){return s.session_number===1}) || pool[0];
+        } else {
+          console.log('[EMBEDDED] URL override: session='+reqSess+(reqTrack?' track='+reqTrack:''));
+        }
+      } else {
+        firstSession = pool.find(function(s){return s.session_number===1}) || pool[0];
+      }
+      if (!firstSession) return;
+      if (!firstSession.session_number && firstSession.session_number !== 0) firstSession.session_number = 1;
+      applySession(firstSession);
+    });
   } else {
     var sessions = await Integration.loadSessions();
     if (sessions && sessions.length > 0) {


### PR DESCRIPTION
PR #2 (commit 99a7969) introduced a ReferenceError because applySession is defined in the bottom IIFE (line 3114) but PR #2 called it from inside _initEmbeddedMode, which lives in the Integration IIFE — a different lexical scope. Runtime threw:

  Uncaught (in promise) ReferenceError: applySession is not defined
      at breathe?embedded=true&session=11:2625:2089

Fix uses Integration's existing 'sessionsLoaded' event (same cross-IIFE pub/sub pattern as 'visualWarmthChanged' at line 3104). _initEmbeddedMode goes back to a simple loadSessions() call (no .then). The bottom IIFE registers a single-fire Integration.on('sessionsLoaded', ...) listener ONLY when in embedded mode. The listener does the URL parsing and calls applySession(firstSession) — in scope, no ReferenceError.

Listener self-unregisters on first fire (var _embeddedOff = ...; off()) to defend against any future case where loadSessions might fire twice.

Listener registered ONLY inside `if (Integration.isEmbedded())` so the standalone branch's own applySession call at line ~3209 is unaffected and there's no double-fire.

What's preserved from PR #2:
- Null-token guard (early-return with warn if data.token missing)
- [EMBEDDED] Auth received | userId log enhancement

What's reverted:
- The .then(function(sessions){...}) block inside _initEmbeddedMode (this was the IIFE-crossing applySession call that threw)

File metrics:
- Both files byte-identical (cmp clean)
- Line count: 3187 → 3220 (+33 readable listener block)
- All six v8.2 Layer 1 grep markers still pass (1 each)
- Two new markers added (each must = 1 per file):
    Integration.on('sessionsLoaded'   ← cross-IIFE listener
    _embeddedOff                       ← single-fire pattern (×2 per file:
                                          declaration + self-unregister)

Audit-gate: paste-back diff approved by Clay before commit. PR pending merge in GitHub UI. Do not auto-merge.