### PR TITLE
fix(visual): reposition coherence rings as halo around Luno

### DIFF
--- a/public/index_v8.html
+++ b/public/index_v8.html
@@ -93,7 +93,7 @@
 .bio-lbl { font-size: 9px; font-weight: 300; color: rgba(120,160,190,0.3); letter-spacing: 1px; text-transform: uppercase; }
 .bio-val { font-size: 13px; font-weight: 300; color: rgba(140,180,210,0.5); transition: color 2s; }
 
-.coh-rings { position: absolute; top: 50%; left: 24px; transform: translateY(-50%); width: 100px; height: 100px; z-index: 15; }
+.coh-rings { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%) scale(2.8); width: 100px; height: 100px; z-index: 15; }
 .coh-rings-label { position: absolute; bottom: -18px; left: 50%; transform: translateX(-50%); font-size: 8px; font-weight: 300; color: rgba(120,160,190,0.25); letter-spacing: 1.5px; text-transform: uppercase; white-space: nowrap; }
 .coh-ring { position: absolute; border-radius: 50%; border: 1.5px solid rgba(120,170,210,0.2); transition: all 1.8s cubic-bezier(0.25, 0.1, 0.25, 1); box-sizing: border-box; }
 .coh-ring-heart { animation: ringDrift1 4s ease-in-out infinite alternate; }

--- a/public/index_v8_production.html
+++ b/public/index_v8_production.html
@@ -93,7 +93,7 @@
 .bio-lbl { font-size: 9px; font-weight: 300; color: rgba(120,160,190,0.3); letter-spacing: 1px; text-transform: uppercase; }
 .bio-val { font-size: 13px; font-weight: 300; color: rgba(140,180,210,0.5); transition: color 2s; }
 
-.coh-rings { position: absolute; top: 50%; left: 24px; transform: translateY(-50%); width: 100px; height: 100px; z-index: 15; }
+.coh-rings { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%) scale(2.8); width: 100px; height: 100px; z-index: 15; }
 .coh-rings-label { position: absolute; bottom: -18px; left: 50%; transform: translateX(-50%); font-size: 8px; font-weight: 300; color: rgba(120,160,190,0.25); letter-spacing: 1.5px; text-transform: uppercase; white-space: nowrap; }
 .coh-ring { position: absolute; border-radius: 50%; border: 1.5px solid rgba(120,170,210,0.2); transition: all 1.8s cubic-bezier(0.25, 0.1, 0.25, 1); box-sizing: border-box; }
 .coh-ring-heart { animation: ringDrift1 4s ease-in-out infinite alternate; }


### PR DESCRIPTION
Move .coh-rings from left-edge anchor to centered halo over Luno orb via uniform 2.8x scale. Locked renderCoherenceRings() function and rings[] sz constants untouched.

Known limitation: container uses static scale. Visually optimal at S1-S300 (covers pilot range). Revisit dynamic scaling when sustained users exceed S1500.

Closes GAP-6 from Phase B audit.