### PR TITLE
feat(nve): production wiring — ABI-orchestrated directive path (Optio…

### DIFF
--- a/public/index_v8.html
+++ b/public/index_v8.html
@@ -460,6 +460,11 @@
   </div>
 </div>
 
+<!-- Module 9 — Narrative Visuals Engine (NVE). External locked module, served via the
+     /modules static mount. Loaded BEFORE the main inline build so NarrativeVisualsEngine
+     exists when the init sequence wires it. -->
+<script src="modules/narrativeVisualsEngine.js"></script>
+
 <script>
 'use strict';
 
@@ -2746,6 +2751,11 @@ var Integration = (function() {
   AbiService.prototype.arrivalComplete=async function(bio){if(!this.sessionKey)throw new Error('No session');return this._req('POST','/api/abi/session/arrival-complete',{session_key:this.sessionKey,biometrics:bio});};
   AbiService.prototype.tick=async function(bio){if(!this.sessionKey)throw new Error('No session');return this._req('POST','/api/abi/session/tick',{session_key:this.sessionKey,biometrics:bio});};
   AbiService.prototype.pause=async function(){if(!this.sessionKey)throw new Error('No session');return this._req('POST','/api/abi/session/pause',{session_key:this.sessionKey});};
+  // NVE prod wiring — phase notification leg. keyOverride lets post-completion phases
+  // (close/mirror/vault/ascent/surface) keep posting after completeSession() nulls
+  // this.sessionKey; the server holds the orchestrator under a grace TTL for them.
+  // The response's events[] (incl. nve_directive) auto-dispatches via _req.
+  AbiService.prototype.phase=async function(phase,keyOverride){var key=keyOverride||this.sessionKey;if(!key)throw new Error('No session');return this._req('POST','/api/abi/session/phase',{session_key:key,phase:phase});};
   AbiService.prototype.resume=async function(){if(!this.sessionKey)throw new Error('No session');return this._req('POST','/api/abi/session/resume',{session_key:this.sessionKey});};
   AbiService.prototype.exit=async function(){if(!this.sessionKey)throw new Error('No session');var r=await this._req('POST','/api/abi/session/exit',{session_key:this.sessionKey});this.sessionKey=null;return r;};
   AbiService.prototype.completeSession=async function(metrics){if(!this.sessionKey)throw new Error('No session');var r=await this._req('POST','/api/abi/session/complete',{session_key:this.sessionKey,metrics:metrics||{}});this.sessionKey=null;return r;};
@@ -2769,6 +2779,10 @@ var Integration = (function() {
   var _activeSessionNumber=0,_activeSessionData=null,_abiSessionActive=false,_abiCoherencePeak=0;
   var _abiMirror=null,_abiAffirmation=null,_abiAdvancement=null,_abiBreathArt=null,_abiModeConfig=null,_tickInterval=null,_lastKnownCoherence=0.25;
   var _abiTickQueue=[],_abiTickQueueMaxSize=60;
+  // NVE prod wiring — phase-notification state. _phaseSessionKey survives completeSession()
+  // nulling _abi.sessionKey (post-shift phases still notify); _pendingPhaseNotifies buffers
+  // transitions that fire before /session/start resolves (the 'arrival' notification).
+  var _phaseSessionKey=null,_pendingPhaseNotifies=[];
 
   function initIntegrations(apiBase){
     _apiBase=(apiBase||window.location.origin||'https://hearty-optimism-production-2eb6.up.railway.app').replace(/\/$/,'');
@@ -2803,6 +2817,7 @@ var Integration = (function() {
     _abiSessionActive=true;_abiCoherencePeak=0;_abiMirror=null;_abiAffirmation=null;_abiAdvancement=null;_abiBreathArt=null;_lastKnownCoherence=0.25;
     if(_stateMachine)_stateMachine.setAbiSessionActive(true,_abi.sessionKey);
     console.log('[ABI] Session registered:',sid,'| sessionKey:',_abi.sessionKey);
+    _phaseSessionKey=_abi.sessionKey;_abiFlushPhaseNotifies();
     return true;
   }
   async function _abiStartSessionWithRetry(sessionNumber,sessionData){
@@ -2814,6 +2829,18 @@ var Integration = (function() {
     }
     console.error('[ABI] All',MAX_ATTEMPTS,'attempts failed. Last error:',lastError?(lastError.message||lastError):'unknown');
     throw lastError||new Error('ABI session start failed after '+MAX_ATTEMPTS+' attempts');
+  }
+  // NVE prod wiring — fire-and-forget phase notification on EVERY SSM phase change
+  // (~11-12/session), so ABI holds the authoritative phase for ALL phases including the
+  // LOW text-heavy ones (arrival/opening/resistance/close). Never blocks the session
+  // clock; on failure the NVE D5 source latch falls back to its local map after 250ms.
+  function _abiNotifyPhase(phase){
+    if(!_abi||(!_phaseSessionKey&&!_abi.sessionKey)){_pendingPhaseNotifies.push(phase);return;}
+    _abi.phase(phase,_phaseSessionKey).catch(function(e){console.warn('[ABI] phase notify failed ('+phase+'):',e.message||e);});
+  }
+  function _abiFlushPhaseNotifies(){
+    var queued=_pendingPhaseNotifies;_pendingPhaseNotifies=[];
+    for(var i=0;i<queued.length;i++)_abiNotifyPhase(queued[i]);
   }
   async function _abiForwardArrivalSample(sample){
     if(!_abiSessionActive)return;
@@ -2840,7 +2867,7 @@ var Integration = (function() {
   function _abiStopTicks(){if(_tickInterval){clearInterval(_tickInterval);_tickInterval=null;}_abiTickQueue=[];}
   function _abiShowIntervention(coaching){_abiStopTicks();if(_stateMachine)_stateMachine.pauseSession();if(_sessionUI){_sessionUI.showCoachingIntervention(coaching,async function(choice){if(choice==='continue'){try{await _abi.resume();}catch(e){}if(_stateMachine)_stateMachine.resumeSession();_abiStartTicks();}else if(choice==='drill'){try{await _abi.selectDrill('five_senses');}catch(e){if(_stateMachine)_stateMachine.resumeSession();}}else if(choice==='exit'){try{await _abi.exit();}catch(e){}_abiSessionActive=false;if(_stateMachine)_stateMachine.setAbiSessionActive(false);_notifyParentExit();}});}}
   async function _abiCompleteSession(){if(!_abiSessionActive)return;var userIdSnapshot=_userId;_abiStopTicks();if(_replay){console.log('[ASCEN] Replay mode — skipping /api/abi/session/complete (no persistence; avoids users.updated_at / Immune / AXIS writes). Mirror still renders via onMirrorReady.');_abiSessionActive=false;if(_stateMachine)_stateMachine.setAbiSessionActive(false);return;}var state=_stateMachine?_stateMachine.getSessionState():{};var metrics={coherence_peak:_abiCoherencePeak,coherence_end:_lastKnownCoherence,cycle_completion_rate:state.totalBreaths>0?Math.min(1,state.breathCount/state.totalBreaths):0.85,breath_count:state.breathCount||0,duration_seconds:state.durationSeconds||0};try{var r=await _abi.completeSession(metrics);_abiMirror=r.mirror||null;_abiAffirmation=r.affirmation||null;_abiAdvancement=r.advancement||null;_abiBreathArt=r.breath_art||null;_verifyOnChain(state.durationSeconds||0);if(_stateMachine&&_stateMachine.getCurrentPhase&&_stateMachine.getCurrentPhase()==='mirror'&&_sessionUI&&_sessionUI.renderMirror)_sessionUI.renderMirror();}catch(e){}_abiSessionActive=false;if(_stateMachine)_stateMachine.setAbiSessionActive(false);}
-  function _abiCleanup(){var userIdSnapshot=_userId;_abiStopTicks();_abiSessionActive=false;_abiCoherencePeak=0;_abiModeConfig=null;_lastKnownCoherence=0.25;_abiMirror=null;_abiAffirmation=null;_abiAdvancement=null;_abiBreathArt=null;if(_abi)_abi.sessionKey=null;if(typeof BiofeedbackSound!=='undefined')BiofeedbackSound.teardown();if(_replay){if(typeof BioBridge!=='undefined')console.log('[ASCEN] Replay mode — H10/GATT preserved (destroyUser skipped)');}else if(userIdSnapshot&&typeof BioBridge!=='undefined')BioBridge.destroyUser(userIdSnapshot);}
+  function _abiCleanup(){var userIdSnapshot=_userId;_abiStopTicks();_abiSessionActive=false;_abiCoherencePeak=0;_abiModeConfig=null;_lastKnownCoherence=0.25;_abiMirror=null;_abiAffirmation=null;_abiAdvancement=null;_abiBreathArt=null;if(_abi)_abi.sessionKey=null;_phaseSessionKey=null;_pendingPhaseNotifies=[];if(typeof BiofeedbackSound!=='undefined')BiofeedbackSound.teardown();if(_replay){if(typeof BioBridge!=='undefined')console.log('[ASCEN] Replay mode — H10/GATT preserved (destroyUser skipped)');}else if(userIdSnapshot&&typeof BioBridge!=='undefined')BioBridge.destroyUser(userIdSnapshot);}
 
   async function postVaultEntry(data){var userIdSnapshot=_userId;try{var headers={'Content-Type':'application/json'};if(_abi&&_abi.token)headers['Authorization']='Bearer '+_abi.token;if(_abi&&_abi.apiKey)headers['x-api-key']=_abi.apiKey;await fetch(_apiBase+'/api/fr/vault',{method:'POST',headers:headers,body:JSON.stringify({user_id:userIdSnapshot,session_number:data.session_number||_activeSessionNumber,vault_response:data.text||'',session_type:'individual'})});}catch(e){}}
   async function postProgress(metrics){if(_replay){console.log('[ASCEN] Replay mode — skipping /api/fr/progress write (pointer frozen, demo account untouched)');return;}var userIdSnapshot=_userId;try{var headers={'Content-Type':'application/json'};if(_abi&&_abi.token)headers['Authorization']='Bearer '+_abi.token;if(_abi&&_abi.apiKey)headers['x-api-key']=_abi.apiKey;await fetch(_apiBase+'/api/fr/progress',{method:'POST',headers:headers,body:JSON.stringify({user_id:userIdSnapshot,session_number:metrics.sessionNumber||_activeSessionNumber,completed:true,coherence_score:metrics.coherencePeak||(_abiCoherencePeak>0?_abiCoherencePeak:0.5),duration_seconds:metrics.durationSeconds||0,session_type:'individual'})});}catch(e){}}
@@ -2850,6 +2877,7 @@ var Integration = (function() {
   function connectToStateMachine(ssm){
     _stateMachine=ssm;
     ssm.on('onPhaseChange',function(phase){
+      _abiNotifyPhase(phase); // NVE prod wiring — EVERY phase routes through ABI (runs before the 'surface' cleanup below)
       if(phase==='arrival'){
         var state=ssm.getSessionState();_activeSessionNumber=state.sessionNumber;_activeSessionData=state.sessionData;
         _abiStartSessionWithRetry(state.sessionNumber,state.sessionData).then(function(success){if(success)console.log('[SSM] ABI registration confirmed — session proceeding');}).catch(function(err){
@@ -3222,6 +3250,15 @@ var BiofeedbackSound = (function() {
 
   // === WIRE MODULES TOGETHER ===
 
+  // ABI → NVE directive bridge (NVE prod wiring §2.3 — THE orchestrated leg).
+  // AbiService and NVE share this document (iframe-embedded per spec Q5), so the
+  // bridge is SAME-WINDOW: directives drained from any ABI response's events[]
+  // are forwarded to NVE's postMessage listener, origin-pinned. The SSM path in
+  // NVE is the 250ms-latch fallback only — never primary for any phase.
+  Integration.getAbi().on('nve_directive', function(data) {
+    window.postMessage({ type: 'NVE_DIRECTIVE', payload: data }, window.location.origin);
+  });
+
   // State Machine → Depth Engine
   SSM.on('onDescentProgress', function(p) {
     DepthEngine.setOceanBgDepthBlend(p);
@@ -3246,6 +3283,17 @@ var BiofeedbackSound = (function() {
 
   // State Machine → Integration Layer
   Integration.connectToStateMachine(SSM);
+
+  // Module 9 — Narrative Visuals Engine (NVE prod wiring §2.2). init() first
+  // (creates #nveCanvas z5 / #nveBgOverlay z2 inside #immersiveView — above
+  // depthCanvas z0 / ocean-bg z1, below Luno z10 / dialogue z20). The SSM
+  // connect is for onBreathPhase/onSessionStart/onSessionReset + the D5
+  // fallback latch only; phase intensity is ABI-driven via the bridge above.
+  // Two-layer lock: NVE never touches water clarity/light/turbulence.
+  NarrativeVisualsEngine.init();
+  NarrativeVisualsEngine.connectToDepthEngine(DepthEngine);
+  NarrativeVisualsEngine.connectToBiometricBridge(BioBridge);
+  NarrativeVisualsEngine.connectToStateMachine(SSM);
 
   // Biometric Bridge → Session UI
   SessionUI.connectToBiometricBridge(BioBridge);

--- a/public/index_v8_production.html
+++ b/public/index_v8_production.html
@@ -460,6 +460,11 @@
   </div>
 </div>
 
+<!-- Module 9 — Narrative Visuals Engine (NVE). External locked module, served via the
+     /modules static mount. Loaded BEFORE the main inline build so NarrativeVisualsEngine
+     exists when the init sequence wires it. -->
+<script src="modules/narrativeVisualsEngine.js"></script>
+
 <script>
 'use strict';
 
@@ -2746,6 +2751,11 @@ var Integration = (function() {
   AbiService.prototype.arrivalComplete=async function(bio){if(!this.sessionKey)throw new Error('No session');return this._req('POST','/api/abi/session/arrival-complete',{session_key:this.sessionKey,biometrics:bio});};
   AbiService.prototype.tick=async function(bio){if(!this.sessionKey)throw new Error('No session');return this._req('POST','/api/abi/session/tick',{session_key:this.sessionKey,biometrics:bio});};
   AbiService.prototype.pause=async function(){if(!this.sessionKey)throw new Error('No session');return this._req('POST','/api/abi/session/pause',{session_key:this.sessionKey});};
+  // NVE prod wiring — phase notification leg. keyOverride lets post-completion phases
+  // (close/mirror/vault/ascent/surface) keep posting after completeSession() nulls
+  // this.sessionKey; the server holds the orchestrator under a grace TTL for them.
+  // The response's events[] (incl. nve_directive) auto-dispatches via _req.
+  AbiService.prototype.phase=async function(phase,keyOverride){var key=keyOverride||this.sessionKey;if(!key)throw new Error('No session');return this._req('POST','/api/abi/session/phase',{session_key:key,phase:phase});};
   AbiService.prototype.resume=async function(){if(!this.sessionKey)throw new Error('No session');return this._req('POST','/api/abi/session/resume',{session_key:this.sessionKey});};
   AbiService.prototype.exit=async function(){if(!this.sessionKey)throw new Error('No session');var r=await this._req('POST','/api/abi/session/exit',{session_key:this.sessionKey});this.sessionKey=null;return r;};
   AbiService.prototype.completeSession=async function(metrics){if(!this.sessionKey)throw new Error('No session');var r=await this._req('POST','/api/abi/session/complete',{session_key:this.sessionKey,metrics:metrics||{}});this.sessionKey=null;return r;};
@@ -2769,6 +2779,10 @@ var Integration = (function() {
   var _activeSessionNumber=0,_activeSessionData=null,_abiSessionActive=false,_abiCoherencePeak=0;
   var _abiMirror=null,_abiAffirmation=null,_abiAdvancement=null,_abiBreathArt=null,_abiModeConfig=null,_tickInterval=null,_lastKnownCoherence=0.25;
   var _abiTickQueue=[],_abiTickQueueMaxSize=60;
+  // NVE prod wiring — phase-notification state. _phaseSessionKey survives completeSession()
+  // nulling _abi.sessionKey (post-shift phases still notify); _pendingPhaseNotifies buffers
+  // transitions that fire before /session/start resolves (the 'arrival' notification).
+  var _phaseSessionKey=null,_pendingPhaseNotifies=[];
 
   function initIntegrations(apiBase){
     _apiBase=(apiBase||window.location.origin||'https://hearty-optimism-production-2eb6.up.railway.app').replace(/\/$/,'');
@@ -2803,6 +2817,7 @@ var Integration = (function() {
     _abiSessionActive=true;_abiCoherencePeak=0;_abiMirror=null;_abiAffirmation=null;_abiAdvancement=null;_abiBreathArt=null;_lastKnownCoherence=0.25;
     if(_stateMachine)_stateMachine.setAbiSessionActive(true,_abi.sessionKey);
     console.log('[ABI] Session registered:',sid,'| sessionKey:',_abi.sessionKey);
+    _phaseSessionKey=_abi.sessionKey;_abiFlushPhaseNotifies();
     return true;
   }
   async function _abiStartSessionWithRetry(sessionNumber,sessionData){
@@ -2814,6 +2829,18 @@ var Integration = (function() {
     }
     console.error('[ABI] All',MAX_ATTEMPTS,'attempts failed. Last error:',lastError?(lastError.message||lastError):'unknown');
     throw lastError||new Error('ABI session start failed after '+MAX_ATTEMPTS+' attempts');
+  }
+  // NVE prod wiring — fire-and-forget phase notification on EVERY SSM phase change
+  // (~11-12/session), so ABI holds the authoritative phase for ALL phases including the
+  // LOW text-heavy ones (arrival/opening/resistance/close). Never blocks the session
+  // clock; on failure the NVE D5 source latch falls back to its local map after 250ms.
+  function _abiNotifyPhase(phase){
+    if(!_abi||(!_phaseSessionKey&&!_abi.sessionKey)){_pendingPhaseNotifies.push(phase);return;}
+    _abi.phase(phase,_phaseSessionKey).catch(function(e){console.warn('[ABI] phase notify failed ('+phase+'):',e.message||e);});
+  }
+  function _abiFlushPhaseNotifies(){
+    var queued=_pendingPhaseNotifies;_pendingPhaseNotifies=[];
+    for(var i=0;i<queued.length;i++)_abiNotifyPhase(queued[i]);
   }
   async function _abiForwardArrivalSample(sample){
     if(!_abiSessionActive)return;
@@ -2840,7 +2867,7 @@ var Integration = (function() {
   function _abiStopTicks(){if(_tickInterval){clearInterval(_tickInterval);_tickInterval=null;}_abiTickQueue=[];}
   function _abiShowIntervention(coaching){_abiStopTicks();if(_stateMachine)_stateMachine.pauseSession();if(_sessionUI){_sessionUI.showCoachingIntervention(coaching,async function(choice){if(choice==='continue'){try{await _abi.resume();}catch(e){}if(_stateMachine)_stateMachine.resumeSession();_abiStartTicks();}else if(choice==='drill'){try{await _abi.selectDrill('five_senses');}catch(e){if(_stateMachine)_stateMachine.resumeSession();}}else if(choice==='exit'){try{await _abi.exit();}catch(e){}_abiSessionActive=false;if(_stateMachine)_stateMachine.setAbiSessionActive(false);_notifyParentExit();}});}}
   async function _abiCompleteSession(){if(!_abiSessionActive)return;var userIdSnapshot=_userId;_abiStopTicks();if(_replay){console.log('[ASCEN] Replay mode — skipping /api/abi/session/complete (no persistence; avoids users.updated_at / Immune / AXIS writes). Mirror still renders via onMirrorReady.');_abiSessionActive=false;if(_stateMachine)_stateMachine.setAbiSessionActive(false);return;}var state=_stateMachine?_stateMachine.getSessionState():{};var metrics={coherence_peak:_abiCoherencePeak,coherence_end:_lastKnownCoherence,cycle_completion_rate:state.totalBreaths>0?Math.min(1,state.breathCount/state.totalBreaths):0.85,breath_count:state.breathCount||0,duration_seconds:state.durationSeconds||0};try{var r=await _abi.completeSession(metrics);_abiMirror=r.mirror||null;_abiAffirmation=r.affirmation||null;_abiAdvancement=r.advancement||null;_abiBreathArt=r.breath_art||null;_verifyOnChain(state.durationSeconds||0);if(_stateMachine&&_stateMachine.getCurrentPhase&&_stateMachine.getCurrentPhase()==='mirror'&&_sessionUI&&_sessionUI.renderMirror)_sessionUI.renderMirror();}catch(e){}_abiSessionActive=false;if(_stateMachine)_stateMachine.setAbiSessionActive(false);}
-  function _abiCleanup(){var userIdSnapshot=_userId;_abiStopTicks();_abiSessionActive=false;_abiCoherencePeak=0;_abiModeConfig=null;_lastKnownCoherence=0.25;_abiMirror=null;_abiAffirmation=null;_abiAdvancement=null;_abiBreathArt=null;if(_abi)_abi.sessionKey=null;if(typeof BiofeedbackSound!=='undefined')BiofeedbackSound.teardown();if(_replay){if(typeof BioBridge!=='undefined')console.log('[ASCEN] Replay mode — H10/GATT preserved (destroyUser skipped)');}else if(userIdSnapshot&&typeof BioBridge!=='undefined')BioBridge.destroyUser(userIdSnapshot);}
+  function _abiCleanup(){var userIdSnapshot=_userId;_abiStopTicks();_abiSessionActive=false;_abiCoherencePeak=0;_abiModeConfig=null;_lastKnownCoherence=0.25;_abiMirror=null;_abiAffirmation=null;_abiAdvancement=null;_abiBreathArt=null;if(_abi)_abi.sessionKey=null;_phaseSessionKey=null;_pendingPhaseNotifies=[];if(typeof BiofeedbackSound!=='undefined')BiofeedbackSound.teardown();if(_replay){if(typeof BioBridge!=='undefined')console.log('[ASCEN] Replay mode — H10/GATT preserved (destroyUser skipped)');}else if(userIdSnapshot&&typeof BioBridge!=='undefined')BioBridge.destroyUser(userIdSnapshot);}
 
   async function postVaultEntry(data){var userIdSnapshot=_userId;try{var headers={'Content-Type':'application/json'};if(_abi&&_abi.token)headers['Authorization']='Bearer '+_abi.token;if(_abi&&_abi.apiKey)headers['x-api-key']=_abi.apiKey;await fetch(_apiBase+'/api/fr/vault',{method:'POST',headers:headers,body:JSON.stringify({user_id:userIdSnapshot,session_number:data.session_number||_activeSessionNumber,vault_response:data.text||'',session_type:'individual'})});}catch(e){}}
   async function postProgress(metrics){if(_replay){console.log('[ASCEN] Replay mode — skipping /api/fr/progress write (pointer frozen, demo account untouched)');return;}var userIdSnapshot=_userId;try{var headers={'Content-Type':'application/json'};if(_abi&&_abi.token)headers['Authorization']='Bearer '+_abi.token;if(_abi&&_abi.apiKey)headers['x-api-key']=_abi.apiKey;await fetch(_apiBase+'/api/fr/progress',{method:'POST',headers:headers,body:JSON.stringify({user_id:userIdSnapshot,session_number:metrics.sessionNumber||_activeSessionNumber,completed:true,coherence_score:metrics.coherencePeak||(_abiCoherencePeak>0?_abiCoherencePeak:0.5),duration_seconds:metrics.durationSeconds||0,session_type:'individual'})});}catch(e){}}
@@ -2850,6 +2877,7 @@ var Integration = (function() {
   function connectToStateMachine(ssm){
     _stateMachine=ssm;
     ssm.on('onPhaseChange',function(phase){
+      _abiNotifyPhase(phase); // NVE prod wiring — EVERY phase routes through ABI (runs before the 'surface' cleanup below)
       if(phase==='arrival'){
         var state=ssm.getSessionState();_activeSessionNumber=state.sessionNumber;_activeSessionData=state.sessionData;
         _abiStartSessionWithRetry(state.sessionNumber,state.sessionData).then(function(success){if(success)console.log('[SSM] ABI registration confirmed — session proceeding');}).catch(function(err){
@@ -3222,6 +3250,15 @@ var BiofeedbackSound = (function() {
 
   // === WIRE MODULES TOGETHER ===
 
+  // ABI → NVE directive bridge (NVE prod wiring §2.3 — THE orchestrated leg).
+  // AbiService and NVE share this document (iframe-embedded per spec Q5), so the
+  // bridge is SAME-WINDOW: directives drained from any ABI response's events[]
+  // are forwarded to NVE's postMessage listener, origin-pinned. The SSM path in
+  // NVE is the 250ms-latch fallback only — never primary for any phase.
+  Integration.getAbi().on('nve_directive', function(data) {
+    window.postMessage({ type: 'NVE_DIRECTIVE', payload: data }, window.location.origin);
+  });
+
   // State Machine → Depth Engine
   SSM.on('onDescentProgress', function(p) {
     DepthEngine.setOceanBgDepthBlend(p);
@@ -3246,6 +3283,17 @@ var BiofeedbackSound = (function() {
 
   // State Machine → Integration Layer
   Integration.connectToStateMachine(SSM);
+
+  // Module 9 — Narrative Visuals Engine (NVE prod wiring §2.2). init() first
+  // (creates #nveCanvas z5 / #nveBgOverlay z2 inside #immersiveView — above
+  // depthCanvas z0 / ocean-bg z1, below Luno z10 / dialogue z20). The SSM
+  // connect is for onBreathPhase/onSessionStart/onSessionReset + the D5
+  // fallback latch only; phase intensity is ABI-driven via the bridge above.
+  // Two-layer lock: NVE never touches water clarity/light/turbulence.
+  NarrativeVisualsEngine.init();
+  NarrativeVisualsEngine.connectToDepthEngine(DepthEngine);
+  NarrativeVisualsEngine.connectToBiometricBridge(BioBridge);
+  NarrativeVisualsEngine.connectToStateMachine(SSM);
 
   // Biometric Bridge → Session UI
   SessionUI.connectToBiometricBridge(BioBridge);

--- a/public/modules/narrativeVisualsEngine.js
+++ b/public/modules/narrativeVisualsEngine.js
@@ -161,6 +161,22 @@ var NarrativeVisualsEngine = (function() {
   // it; biofeedback layers clamp to it as a lower bound. Tunable on-device (placeholder).
   var BIOFEEDBACK_MIN_OPACITY = 0.35;
 
+  // ── D5 PER-PHASE SOURCE LATCH (prod wiring) ──
+  // ABI is the primary driver of the phase→intensity ease (nve_directive via the
+  // same-window NVE_DIRECTIVE postMessage). The SSM onPhaseChange path is the
+  // offline/latency FALLBACK only: on each phase change we latch 'pending' and arm
+  // a 250ms timer; a directive arriving first wins (timer cancelled), the timer
+  // firing first eases from the local map, and a LATE directive still overrides.
+  // The local PHASE_INTENSITY map is consulted in BOTH cases (D1 — NVE owns the
+  // constants; the directive carries phase intent, never a numeric target).
+  var NVE_DIRECTIVE_FALLBACK_MS = 250;
+  var _intensitySource = null;        // null | 'pending' | 'abi' | 'ssm-fallback'
+  var _latchPhase = null;             // phase of the most recent SSM onPhaseChange
+  var _directiveFallbackTimer = null;
+  var _regulationOk = true;           // D2: ABI-supplied flag, recorded as input only —
+                                      // no behavioral clamp yet (on-device tuning decision);
+                                      // floor authority stays client-side regardless.
+
   // Ease intensity toward a target over ~600–800ms (default 700) — no hard cuts. Uses a
   // setInterval tween (independent of the field RAF, so it still advances while the field is
   // frozen for gap_reveal) and nudges the field RAF each step so presence repaints smoothly.
@@ -183,6 +199,43 @@ var NarrativeVisualsEngine = (function() {
       if (_nveField.length) _nveStartRAF();
       if (t >= 1) { _intensity = target; clearInterval(_intensityTween); _intensityTween = null; }
     }, 16);
+  }
+
+  // D5.1 — SSM onPhaseChange leg: latch 'pending', arm the fallback timer, do NOT ease yet.
+  // Double-drive is structurally impossible: (a) the fallback ease is gated behind this latch
+  // and never fires once the source for the current phase is 'abi'; (b) _easeIntensityTo
+  // clears any in-flight tween before starting, so at most one tween exists; (c) the timer is
+  // cancelled on directive arrival and re-armed only by the next phase change.
+  function _latchPhaseIntensity(phase) {
+    _latchPhase = phase;
+    _intensitySource = 'pending';
+    if (_directiveFallbackTimer) { clearTimeout(_directiveFallbackTimer); }
+    _directiveFallbackTimer = setTimeout(function() {
+      _directiveFallbackTimer = null;
+      if (_intensitySource !== 'abi' && _latchPhase === phase) {   // D5.3 — no directive arrived
+        _intensitySource = 'ssm-fallback';
+        console.log('[NVE] intensity | phase=' + phase + ' source=ssm-fallback');
+        _easeIntensityTo(PHASE_INTENSITY[phase] != null ? PHASE_INTENSITY[phase] : DEFAULT_INTENSITY, 700);
+      }
+    }, NVE_DIRECTIVE_FALLBACK_MS);
+  }
+
+  // D5.2/D5.4 — ABI directive leg (from the NVE_DIRECTIVE postMessage bridge). ABI is
+  // authoritative whenever present: before the timer it cancels the fallback; after a
+  // fallback already eased it re-eases (override). A directive for a phase the SSM has
+  // already moved past is STALE and ignored — it must not fight the newer phase's latch.
+  function _onAbiPhaseDirective(payload) {
+    var phase = payload.phase;
+    if (phase !== _latchPhase) {
+      console.log('[NVE] stale directive ignored | directive=' + phase + ' current=' + _latchPhase);
+      return;
+    }
+    if (_directiveFallbackTimer) { clearTimeout(_directiveFallbackTimer); _directiveFallbackTimer = null; }
+    _intensitySource = 'abi';
+    _regulationOk = (payload.regulation_ok !== false);
+    console.log('[NVE] intensity | phase=' + phase + ' source=abi regulation_ok=' + _regulationOk);
+    _easeIntensityTo(PHASE_INTENSITY[phase] != null ? PHASE_INTENSITY[phase] : DEFAULT_INTENSITY,
+                     payload.ease_ms != null ? payload.ease_ms : 700);
   }
 
   // The NVE field is a BIOFEEDBACK layer when it is breath/coherence-coupled (environment_sync
@@ -1379,6 +1432,11 @@ var NarrativeVisualsEngine = (function() {
     _clearBlueprintLines();
     _nveBreathSyncField = false;
     _nveFieldDissolve(fd);
+    // Clear the D5 latch so a stale fallback timer can't fire after reset.
+    if (_directiveFallbackTimer) { clearTimeout(_directiveFallbackTimer); _directiveFallbackTimer = null; }
+    _intensitySource = null;
+    _latchPhase = null;
+    _regulationOk = true;
     _easeIntensityTo(DEFAULT_INTENSITY, fd); // ease presence back to neutral ambient
     _breathSyncActive = false;
     _ladderZone = null;
@@ -1394,10 +1452,10 @@ var NarrativeVisualsEngine = (function() {
 
   // ── PHASE-BASED DEFAULT VISUALS ──
   function _applyPhaseDefaults(phase) {
-    // Phase-gated intensity — THE orchestrated path. _applyPhaseDefaults is only ever called
-    // from the SSM onPhaseChange handler (connectToStateMachine), so this is the single place
-    // the phase→intensity map is consulted. Eased (no hard cut); unlisted phases → default.
-    _easeIntensityTo(PHASE_INTENSITY[phase] != null ? PHASE_INTENSITY[phase] : DEFAULT_INTENSITY, 700);
+    // Phase-gated intensity — routed through the D5 source latch (prod wiring). The ABI
+    // nve_directive is PRIMARY for every phase; this SSM leg only arms the 250ms fallback.
+    // The per-phase trigger() defaults below are presentation mechanics and run unchanged.
+    _latchPhaseIntensity(phase);
     switch(phase) {
       case 'arrival':
         trigger('text_visible', {});
@@ -1501,10 +1559,17 @@ var NarrativeVisualsEngine = (function() {
     console.log('[NVE] Connected to Depth Engine');
   }
 
-  // ── postMessage INTERFACE (for iframe embedding) ──
+  // ── postMessage INTERFACE (same-window bridge + iframe embedding) ──
   window.addEventListener('message', function(event) {
+    // Origin guard (Q5): accept same-window posts (the AbiService→NVE bridge and the
+    // file:// harness both post from this window) or same-origin posts. Cross-origin /
+    // cross-frame messages are rejected.
+    if (event.source !== window && event.origin !== window.location.origin) return;
     if (!event.data) return;
-    if (event.data.type === 'NARRATIVE_VISUAL') {
+    if (event.data.type === 'NVE_DIRECTIVE') {
+      var dp = event.data.payload || {};
+      if (dp.kind === 'phase_intensity') _onAbiPhaseDirective(dp);
+    } else if (event.data.type === 'NARRATIVE_VISUAL') {
       var payload = event.data.payload || {};
       trigger(payload.visual, {
         duration_seconds: payload.duration_seconds,
@@ -1528,6 +1593,9 @@ var NarrativeVisualsEngine = (function() {
       breathSyncActive: _breathSyncActive,
       performanceTier: _performanceTier,
       intensity: _intensity,
+      intensitySource: _intensitySource,
+      latchPhase: _latchPhase,
+      regulationOk: _regulationOk,
       warmthAccumulated: _warmthAccumulated,
       currentPhase: _currentPhase,
       currentSession: _currentSession

--- a/server.js
+++ b/server.js
@@ -31,6 +31,9 @@ app.use('/assets/crowns', express.static(path.join(__dirname, 'src/assets/crowns
 // ── TTS AUDIO — cached ElevenLabs audio files ───────────────
 app.use('/audio/tts', express.static(path.join(__dirname, 'public/audio/tts')));
 
+// ── FRONTEND MODULES — NVE et al., loaded by /breathe ───────
+app.use('/modules', express.static(path.join(__dirname, 'public/modules')));
+
 // ── V8 IMMERSIVE FRONTEND — canonical participant experience ─
 app.get('/breathe', (req, res) => {
   res.set('Cache-Control', 'no-cache, no-store, must-revalidate');

--- a/src/abi/sessionOrchestrator.js
+++ b/src/abi/sessionOrchestrator.js
@@ -71,6 +71,17 @@ function _zoneFromScore(score) {
   if (score >= NS3_ZONES.APPROACHING.min) return NS3_ZONES.APPROACHING.label;
   return NS3_ZONES.BELOW_WINDOW.label;
 }
+
+// ── BROWSER PHASE WHITELIST (NVE prod wiring) ───────────────
+// The 13 browser SSM phases (index_v8 PHASE_ORDER). The browser
+// notifies ABI of every transition via POST /api/abi/session/phase;
+// onPhaseTransition() validates against this list. Held separate
+// from the endpoint-inferred sessionPhase — see uiPhase below.
+const BROWSER_PHASES = [
+  'surface', 'arrival', 'descent', 'opening', 'resistance',
+  'before_the_breath', 'breathing', 'shift', 'close', 'mirror',
+  'vault', 'ascent', 'surface_return'
+];
 const breathArtEngine = require('./breathArtEngine');
 const ipfsService = require('../services/ipfsService');
 const artAggregationEngine = require('./artAggregationEngine');
@@ -102,6 +113,7 @@ const pool = new Pool({ connectionString: process.env.DATABASE_URL });
  *   onOfferDrill(drillOptions)— show drill selection (NEW)
  *   onIdentityChallenge(cfg)  — show identity gate UI (NEW)
  *   onStateChange(state)      — state engine update for frontend (NEW)
+ *   onNveDirective(data)      — NVE presence directive for the visual layer (NVE wiring)
  * @returns {Object} - Orchestrator with lifecycle methods
  */
 function createOrchestrator(callbacks = {}) {
@@ -115,7 +127,8 @@ function createOrchestrator(callbacks = {}) {
     onOfferExit = () => {},
     onOfferDrill = () => {},
     onIdentityChallenge = () => {},
-    onStateChange = () => {}
+    onStateChange = () => {},
+    onNveDirective = () => {}
   } = callbacks;
 
   // ── INTERNAL STATE ──────────────────────────────────────
@@ -133,6 +146,11 @@ function createOrchestrator(callbacks = {}) {
   let biometricsAvailable = false;
   let arrivalBaseline = null;
   let sessionPhase = 'init';
+  // Authoritative browser UI phase (NVE wiring). Set by onPhaseTransition()
+  // on every browser _setPhase(). Held SEPARATE from sessionPhase: that
+  // field is endpoint-inferred and has behavioral guards (e.g. tick requires
+  // 'breathing'); overwriting it with UI phases would regress those guards.
+  let uiPhase = null;
 
   // ── NEW SYSTEM INSTANCES ────────────────────────────────
   let stateEngine = null;
@@ -164,6 +182,7 @@ function createOrchestrator(callbacks = {}) {
   let ns3WindowStart = null;   // ISO timestamp of current window's first tick
   let ns3UserIdInt = null;     // integer users.id resolved once at session start (ns3_snapshots.user_id is INTEGER)
   let ns3Summary = null;       // populated on session complete
+  let lastNs3Zone = null;      // most recent per-tick NS3 zone — regulation_ok input for onPhaseTransition (NVE wiring)
 
   // ── SOMATIC RESET STATE ───────────────────────────────────
   let somaticActive = false;
@@ -1054,6 +1073,7 @@ function createOrchestrator(callbacks = {}) {
             zone: ns3Result.zone,
             coherence: ns3Result.components?.coherence?.raw ?? null,
           };
+          lastNs3Zone = ns3Result.zone;
 
           // Accumulate into 5-tick persistence window
           if (!ns3WindowStart) ns3WindowStart = new Date().toISOString();
@@ -2375,6 +2395,40 @@ function createOrchestrator(callbacks = {}) {
   }
 
   // ═══════════════════════════════════════════════════════════
+  // BROWSER PHASE TRANSITION (NVE prod wiring — input leg)
+  // ═══════════════════════════════════════════════════════════
+  // Fired by POST /api/abi/session/phase on EVERY browser _setPhase()
+  // (~11-12/session), including the LOW text-heavy phases that have no
+  // other backend notification (arrival/opening/resistance/close).
+  // ABI holds the authoritative phase in uiPhase and emits the presence
+  // directive. Per D1 the directive carries phase INTENT only — NVE owns
+  // PHASE_INTENSITY and the translation. Per D2 ABI supplies regulation_ok
+  // only; the biofeedback floor stays client-side.
+
+  function onPhaseTransition(phase) {
+    if (!BROWSER_PHASES.includes(phase)) {
+      return { accepted: false, phase };
+    }
+    uiPhase = phase;
+
+    // regulation_ok: in-window = approaching/optimal. below_window and
+    // overdrive are outside the regulation window. No NS3 data yet
+    // (pre-breathing phases have no tick stream) defaults to true.
+    const regulation_ok = lastNs3Zone === null
+      ? true
+      : !(lastNs3Zone === NS3_ZONES.BELOW_WINDOW.label || lastNs3Zone === NS3_ZONES.OVERDRIVE.label);
+
+    onNveDirective({
+      kind: 'phase_intensity',
+      phase,
+      ease_ms: 700,
+      regulation_ok
+    });
+
+    return { accepted: true, phase, regulation_ok };
+  }
+
+  // ═══════════════════════════════════════════════════════════
   // PUBLIC API
   // ═══════════════════════════════════════════════════════════
 
@@ -2394,12 +2448,14 @@ function createOrchestrator(callbacks = {}) {
     onBLEDisconnect,      // Polar H10 drops
     onBLEReconnect,       // Polar H10 returns
     onSomaticComplete,    // somatic exercise finished — pivot or proceed
+    onPhaseTransition,    // browser SSM phase notification — NVE directive emitter (NVE wiring)
 
     // Getters for session engine
     getAdaptedSession: () => adaptedSession,
     getPauseHandler: () => pauseHandler,
     getActiveSeconds: () => pauseHandler ? pauseHandler.getActiveSeconds() : 0,
     getSessionPhase: () => sessionPhase,
+    getUiPhase: () => uiPhase,
     ispaused: () => pauseHandler ? pauseHandler.state !== PAUSE_STATE.ACTIVE : false,
 
     // New getters

--- a/src/routes/abiRoutes.js
+++ b/src/routes/abiRoutes.js
@@ -34,6 +34,13 @@ const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 // One orchestrator per active session.
 const activeSessions = new Map();
 
+// Grace TTL for completed sessions (NVE prod wiring): /session/complete
+// fires at the browser's 'shift' phase, but close/mirror/vault/ascent/
+// surface still POST /session/phase afterward — the orchestrator must
+// stay resolvable for them. Entries are marked completedAt and deleted
+// after this TTL instead of immediately.
+const COMPLETED_SESSION_GRACE_MS = 10 * 60 * 1000;
+
 function makeSessionKey(userId, sessionId) {
   return `${userId}:${sessionId}`;
 }
@@ -160,6 +167,11 @@ router.post('/session/start', async (req, res) => {
         const evt = { type: 'state_change', stateData, ts: Date.now() };
         pendingEvents.push(evt);
         sessionStateManager.pushEvent(dbSessionKey, evt).catch(() => {});
+      },
+      onNveDirective: (data) => {
+        // Transient visual-layer signal — no DB persistence (no replay value,
+        // ~11-12/session would only add write volume).
+        pendingEvents.push({ type: 'nve_directive', data, ts: Date.now() });
       }
     });
 
@@ -741,6 +753,46 @@ router.post('/session/exit', async (req, res) => {
 });
 
 
+// ── PHASE NOTIFICATION (NVE prod wiring — input leg) ────────
+// POST /api/abi/session/phase
+// Body: { session_key, phase }  — phase ∈ browser PHASE_ORDER (13 values)
+// Fired by the browser on EVERY SSM _setPhase() (~11-12/session), so ABI
+// holds the authoritative phase for ALL phases — including the LOW
+// text-heavy ones (arrival/opening/resistance/close) that have no other
+// backend notification. The orchestrator emits the nve_directive into
+// pendingEvents, which rides back in THIS response's events[] — the
+// browser bridge forwards it to NVE (same-window postMessage).
+
+router.post('/session/phase', async (req, res) => {
+  try {
+    const phase = req.body?.phase;
+    if (!phase) return res.status(400).json({ error: 'phase required' });
+
+    const { session } = resolveSession(req);
+    if (!session) {
+      // No orchestrator (redeploy / expired grace TTL). The browser-side
+      // NVE D5 source latch falls back to its local map after 250ms.
+      return res.status(404).json({ error: 'Session not found', events: [] });
+    }
+
+    const result = session.abi.onPhaseTransition(phase);
+    if (!result.accepted) {
+      return res.status(400).json({ error: `Unknown phase: ${phase}` });
+    }
+
+    res.json({
+      success: true,
+      phase: result.phase,
+      regulation_ok: result.regulation_ok,
+      events: drainEvents(session)
+    });
+  } catch (error) {
+    Sentry.captureException(error);
+    res.status(500).json({ error: 'phase notification failed' });
+  }
+});
+
+
 // ── DRILL SELECTION ─────────────────────────────────────────
 // POST /api/abi/session/drill-select  (legacy)
 // POST /api/abi/drill/select          (v8 pattern)
@@ -874,9 +926,19 @@ router.post('/session/complete', async (req, res) => {
     await sessionStateManager.updateSessionState(sk, { phase: 'completed' });
     await sessionStateManager.deactivateSession(sk);
 
-    // Clean up in-memory
-    if (key) activeSessions.delete(key);
-    if (sk && sk !== key) activeSessions.delete(sk);
+    // Clean up in-memory — DEFERRED by a grace TTL (NVE prod wiring).
+    // The browser completes the ABI session at 'shift', but the phases
+    // AFTER it (close/mirror/vault/ascent/surface) still notify
+    // /session/phase and need the orchestrator resolvable so the
+    // nve_directive path stays primary for them (D4: no LOW phase runs
+    // on the SSM fallback). Real post-shift arc is ~1-3 min; 10 min is
+    // a safe ceiling. DB deactivation above is immediate and unchanged.
+    session.completedAt = Date.now();
+    const graceTimer = setTimeout(() => {
+      if (key) activeSessions.delete(key);
+      if (sk && sk !== key) activeSessions.delete(sk);
+    }, COMPLETED_SESSION_GRACE_MS);
+    if (graceTimer.unref) graceTimer.unref();
 
     res.json({ success: true, result, events });
   } catch (error) {

--- a/tests/harness/nveC2.harness.html
+++ b/tests/harness/nveC2.harness.html
@@ -374,11 +374,14 @@ function runAcceptance() {
           check('B2 biofeedback floor holds', minOp > 0 && floorOp >= minOp,
             'layerOpacity@intensity0=' + floorOp.toFixed(2) + ' floor=' + minOp.toFixed(2));
 
-          // ── B3 — phase→intensity, eased not stepped (Mock SSM onPhaseChange = the ABI path) ──
+          // ── B3 — phase→intensity, eased not stepped (SSM leg = D5 FALLBACK path; no ABI in
+          // the harness, so the 250ms source latch times out and the local map drives).
+          // Timing: fallback arms at 250ms + 700ms ease → settled ~950ms; mid-sample inside
+          // the 250–950ms ease window.
           NVE.reset(0);
           SSM.emit('onPhaseChange', 'arrival');                      // text-heavy → LOW
           setTimeout(function() {
-            var iLow = NVE.nveField.intensity();
+            var iLow = NVE.nveField.intensity();                     // settled at 0.25 (fallback)
             SSM.emit('onPhaseChange', 'before_the_breath');          // gap/breath → HIGH
             setTimeout(function() {
               var iMid = NVE.nveField.intensity();                   // mid-ease
@@ -388,11 +391,68 @@ function runAcceptance() {
                   iHigh > iLow + 0.3 && iMid > iLow && iMid < iHigh,
                   'arrival=' + iLow.toFixed(2) + ' mid=' + iMid.toFixed(2) +
                   ' before_the_breath=' + iHigh.toFixed(2));
-                var passed = results.filter(function(r) { return r.ok; }).length;
-                log('ACCEPTANCE: ' + passed + '/' + results.length + ' passed', passed === results.length ? 'pass' : 'fail');
+
+                // ── D5 — ABI directive + per-phase source latch (prod wiring) ──
+                // window.postMessage delivery is async in browsers — every post is
+                // followed by a short wait before asserting.
+                NVE.reset(0);
+                SSM.emit('onPhaseChange', 'arrival');
+                var d5aPending = NVE.getState().intensitySource === 'pending';
+                setTimeout(function() {
+                  check('D5a no directive → fallback at 250ms (pending→ssm-fallback)',
+                    d5aPending && NVE.getState().intensitySource === 'ssm-fallback',
+                    'pending=' + d5aPending + ' source=' + NVE.getState().intensitySource);
+
+                  SSM.emit('onPhaseChange', 'opening');
+                  window.postMessage({ type: 'NVE_DIRECTIVE',
+                    payload: { kind: 'phase_intensity', phase: 'opening', ease_ms: 700, regulation_ok: true } }, '*');
+                  setTimeout(function() {
+                    check('D5b directive before timer wins (source=abi)',
+                      NVE.getState().intensitySource === 'abi',
+                      'source=' + NVE.getState().intensitySource);
+                    setTimeout(function() {
+                      check('D5b fallback timer cancelled (source stays abi past 250ms)',
+                        NVE.getState().intensitySource === 'abi',
+                        'source=' + NVE.getState().intensitySource);
+
+                      SSM.emit('onPhaseChange', 'resistance');
+                      setTimeout(function() {
+                        var fellBack = NVE.getState().intensitySource === 'ssm-fallback';
+                        window.postMessage({ type: 'NVE_DIRECTIVE',
+                          payload: { kind: 'phase_intensity', phase: 'resistance', ease_ms: 700, regulation_ok: false } }, '*');
+                        setTimeout(function() {
+                          check('D5c late directive overrides fallback (abi authoritative)',
+                            fellBack && NVE.getState().intensitySource === 'abi' && NVE.getState().regulationOk === false,
+                            'fellBack=' + fellBack + ' source=' + NVE.getState().intensitySource +
+                            ' regOk=' + NVE.getState().regulationOk);
+
+                          SSM.emit('onPhaseChange', 'close');
+                          window.postMessage({ type: 'NVE_DIRECTIVE',
+                            payload: { kind: 'phase_intensity', phase: 'resistance', ease_ms: 700, regulation_ok: true } }, '*');
+                          setTimeout(function() {
+                            check('D5d stale-phase directive ignored (latch holds current phase)',
+                              NVE.getState().intensitySource === 'pending' && NVE.getState().latchPhase === 'close',
+                              'source=' + NVE.getState().intensitySource + ' latch=' + NVE.getState().latchPhase);
+
+                            SSM.emit('onPhaseChange', 'before_the_breath');
+                            window.postMessage({ type: 'NVE_DIRECTIVE',
+                              payload: { kind: 'phase_intensity', phase: 'before_the_breath', ease_ms: 700, regulation_ok: true } }, '*');
+                            setTimeout(function() {
+                              check('D1 directive maps phase→intensity from LOCAL map (target 0.85)',
+                                NVE.getState().intensitySource === 'abi' && NVE.nveField.intensityTarget() === 0.85,
+                                'target=' + NVE.nveField.intensityTarget());
+                              var passed = results.filter(function(r) { return r.ok; }).length;
+                              log('ACCEPTANCE: ' + passed + '/' + results.length + ' passed', passed === results.length ? 'pass' : 'fail');
+                            }, 100);
+                          }, 100);
+                        }, 100);
+                      }, 320);
+                    }, 320);
+                  }, 100);
+                }, 320);
               }, 700);
-            }, 200);
-          }, 800);
+            }, 600);
+          }, 1100);
         }, 1400);
       }, 1600);
     }, 700);

--- a/tests/harness/nveC2Smoke.js
+++ b/tests/harness/nveC2Smoke.js
@@ -44,9 +44,17 @@ function fakeEl(tag) {
   };
 }
 const body = fakeEl('body');
+/* Message shim (prod wiring): captures the module's 'message' listener so the
+ * NVE_DIRECTIVE postMessage path is testable headless. Dispatch is synchronous;
+ * event.source is the sandbox window itself (same-window bridge semantics). */
+const messageListeners = [];
 const sandbox = {
   window: {
-    addEventListener() {}, devicePixelRatio: 1, innerWidth: 1280, innerHeight: 800,
+    addEventListener(type, fn) { if (type === 'message') messageListeners.push(fn); },
+    postMessage(data) {
+      messageListeners.forEach(fn => fn({ data, origin: 'http://localhost', source: sandbox.window }));
+    },
+    devicePixelRatio: 1, innerWidth: 1280, innerHeight: 800,
     getComputedStyle() { return { opacity: '1', animationPlayState: 'running' }; },
   },
   document: {
@@ -203,6 +211,56 @@ function fail(msg) { console.log('  FAIL ' + msg); failures++; }
   const newCode = stateBlock + engineBlock;
   check('A4 new field code: zero .particle refs', !/\.particle/.test(newCode.replace(/narrative-particle/g, '')));
   check('A4 new field code: zero oceanBg refs', !/oceanBg/.test(newCode));
+
+  // ── D5 series: ABI directive + per-phase source latch (prod wiring) ──
+  // Mock SSM bus — same shape the browser harness uses.
+  const SSMmock = {
+    handlers: {},
+    on(ev, fn) { (this.handlers[ev] = this.handlers[ev] || []).push(fn); },
+    emit(ev, d) { (this.handlers[ev] || []).forEach(fn => fn(d)); },
+  };
+  NVE.connectToStateMachine(SSMmock);
+
+  // D5a — SSM phase change latches 'pending' (no immediate ease); fallback engages after 250ms
+  SSMmock.emit('onPhaseChange', 'arrival');
+  check('D5a phase change latches pending (no immediate ease)',
+    NVE.getState().intensitySource === 'pending', 'source=' + NVE.getState().intensitySource);
+  await new Promise(r => setTimeout(r, 320));
+  check('D5a fallback engages after 250ms (source=ssm-fallback, local map target)',
+    NVE.getState().intensitySource === 'ssm-fallback' && NVE.nveField.intensityTarget() === 0.25,
+    'source=' + NVE.getState().intensitySource + ' target=' + NVE.nveField.intensityTarget());
+
+  // D5b — directive arriving BEFORE the timer wins; fallback never fires
+  SSMmock.emit('onPhaseChange', 'opening');
+  sandbox.window.postMessage({ type: 'NVE_DIRECTIVE', payload: { kind: 'phase_intensity', phase: 'opening', ease_ms: 50, regulation_ok: true } });
+  check('D5b directive before timer wins (source=abi)',
+    NVE.getState().intensitySource === 'abi', 'source=' + NVE.getState().intensitySource);
+  await new Promise(r => setTimeout(r, 320));
+  check('D5b fallback timer cancelled (source stays abi past 250ms)',
+    NVE.getState().intensitySource === 'abi', 'source=' + NVE.getState().intensitySource);
+
+  // D5c — LATE directive still overrides an already-eased fallback (ABI authoritative)
+  SSMmock.emit('onPhaseChange', 'resistance');
+  await new Promise(r => setTimeout(r, 320));
+  check('D5c no directive -> fallback eased', NVE.getState().intensitySource === 'ssm-fallback');
+  sandbox.window.postMessage({ type: 'NVE_DIRECTIVE', payload: { kind: 'phase_intensity', phase: 'resistance', ease_ms: 50, regulation_ok: false } });
+  check('D5c late directive overrides fallback (source=abi, regulation_ok recorded)',
+    NVE.getState().intensitySource === 'abi' && NVE.getState().regulationOk === false,
+    'source=' + NVE.getState().intensitySource + ' regOk=' + NVE.getState().regulationOk);
+
+  // D5d — stale directive (phase the SSM already moved past) is ignored
+  SSMmock.emit('onPhaseChange', 'close');
+  sandbox.window.postMessage({ type: 'NVE_DIRECTIVE', payload: { kind: 'phase_intensity', phase: 'resistance', ease_ms: 50, regulation_ok: true } });
+  check('D5d stale directive ignored (latch stays pending for current phase)',
+    NVE.getState().intensitySource === 'pending' && NVE.getState().latchPhase === 'close',
+    'source=' + NVE.getState().intensitySource + ' latch=' + NVE.getState().latchPhase);
+
+  // D1 — directive carries phase INTENT; NVE translates via its LOCAL map
+  SSMmock.emit('onPhaseChange', 'before_the_breath');
+  sandbox.window.postMessage({ type: 'NVE_DIRECTIVE', payload: { kind: 'phase_intensity', phase: 'before_the_breath', ease_ms: 50, regulation_ok: true } });
+  check('D1 directive maps phase->intensity from the local PHASE_INTENSITY map (0.85)',
+    NVE.getState().intensitySource === 'abi' && NVE.nveField.intensityTarget() === 0.85,
+    'target=' + NVE.nveField.intensityTarget());
 
   console.log(failures === 0 ? '\nALL CHECKS PASSED' : '\n' + failures + ' CHECK(S) FAILED');
   process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
…n A, D1-D5 complete)

Implements docs/reviews/NVE_PROD_WIRING_PREREQUISITE.md (§2 wiring scope, whole per D4 — no staging). Phase/visual/intensity now flows THROUGH ABI; the SSM path survives only as the D5 250ms-latch fallback.

Backend:
- POST /api/abi/session/phase (abiRoutes) — fired on EVERY browser _setPhase (~11-12/session), so ABI holds authoritative phase for ALL phases incl. the LOW text-heavy ones (arrival/opening/resistance/close)
- sessionOrchestrator.onPhaseTransition(): validates against BROWSER_PHASES, holds uiPhase SEPARATE from endpoint-inferred sessionPhase (zero guard regression), emits nve_directive {kind, phase, ease_ms, regulation_ok}
- regulation_ok from latest NS3 zone (out = below_window/overdrive; no-data = true) — captured-but-inert client-side per D2; floor stays in NVE
- /session/complete now defers in-memory deletion by a 10-min grace TTL so close/mirror/vault/ascent still resolve post-completion (D4-critical)
- server.js: /modules static mount (NVE script was previously unreachable)

Frontend (dual files, byte-identical a03436d):
- NVE module loaded + init/connects in the wiring block (z5/z2 in #immersiveView; two-layer lock untouched)
- AbiService.phase() + Integration._abiNotifyPhase: fire-and-forget notify on every onPhaseChange, buffered until /session/start resolves, session key retained past completeSession for post-shift phases
- Same-window ABI→NVE bridge: AbiService.on(nve_directive) → postMessage(NVE_DIRECTIVE, window.location.origin)

NVE module (locked — Plan Mode + verify-ascen):
- D5 per-phase source latch (N=250ms): pending → abi (directive wins, timer cancelled) | ssm-fallback (timer fires) | late directive overrides | stale- phase directive ignored; double-drive structurally impossible (latch gate + single-tween _easeIntensityTo)
- NVE_DIRECTIVE handler maps phase→intensity via the LOCAL map (D1); origin/ same-window guard on the message listener; latch state in getState()
- Constants untouched: PHASE_INTENSITY, BIOFEEDBACK_MIN_OPACITY, tier budgets full=44/reduced=18

Verification:
- curl: 13/13 phases → one directive each; 400/404 paths; post-complete grace TTL holds for close/mirror/vault/ascent
- Node smoke: all original + 8 new D-checks pass
- Browser harness: 15/15 (original 9 incl. retimed B3 + D5a-d + D1)
- E2E /breathe?replay=1: every phase source=abi incl. LOW phases; forced offline window → resistance falls back at 250ms; restore → abi resumes