### PR TITLE
fix(v8): make the source gate BLE-aware so an H10 sensor never strand…

### DIFF
--- a/public/index_v8.html
+++ b/public/index_v8.html
@@ -2490,7 +2490,7 @@ var SessionUI = (function() {
   var _stateMachine=null,_biometricBridge=null,_dialogueDelivery=null,_integration=null,_boundUserId=null,_bleButtonAvailable=false;
   var _baselineReady=false,_synthFallbackTimer=null;
   var _sawH10=false,_sawSynthetic=false,_explicitSyntheticOptIn=false,_continueClickCount=0;
-  function _enableTapButton(source){_baselineReady=true;if(_synthFallbackTimer){clearTimeout(_synthFallbackTimer);_synthFallbackTimer=null;}var tp=$('tapP');if(tp){tp.classList.remove('tap-disabled');}var sub=$('tapSub');if(sub){sub.textContent='Ready. Tap when you are.';}console.log('[UI] Session start button enabled — baseline:',source);}
+  function _enableTapButton(source){_baselineReady=true;if(_synthFallbackTimer){clearTimeout(_synthFallbackTimer);_synthFallbackTimer=null;}var tp=$('tapP');if(tp){tp.classList.remove('tap-disabled');}var sub=$('tapSub');if(sub){sub.textContent='Ready. Tap when you are.';}if(source==='h10')_hideSourceGate();console.log('[UI] Session start button enabled — baseline:',source);}
   function _updateTapSubtitle(text){var sub=$('tapSub');if(sub)sub.textContent=text;}
   function _initSrcBadge(){if($('srcBadge'))return;var b=document.createElement('div');b.id='srcBadge';b.className='src-hidden';b.innerHTML='<span class="src-pip"></span><span id="srcLbl">SYNTHETIC</span>';document.body.appendChild(b);}
   function _setSrcBadge(source){var b=$('srcBadge');if(!b)return;var lbl=$('srcLbl');if(source==='h10'){b.className='src-h10';if(lbl)lbl.textContent='H10 • LIVE';}else if(source==='synthetic'){b.className='src-synthetic';if(lbl)lbl.textContent='SYNTHETIC';}else{b.className='src-hidden';}}
@@ -2523,7 +2523,7 @@ var SessionUI = (function() {
     var tapP=$('tapP');if(tapP){tapP.addEventListener('click',async function(){if(tapP.classList.contains('tap-disabled'))return;if(_dialogueDelivery)await _dialogueDelivery.unlockAudio();if(_stateMachine)_stateMachine.advancePhase();});}
     // Source gate: at 15s without BLE pairing, show explicit choice overlay (no silent synthetic fallback)
     _initSrcBadge();
-    _synthFallbackTimer=setTimeout(function(){if(!_baselineReady)_showSourceGate();},15000);
+    _synthFallbackTimer=setTimeout(function(){if(!_baselineReady&&(!_biometricBridge||_biometricBridge.getActiveSource(_boundUserId)!=='h10'))_showSourceGate();},15000);
     var vaultSeal=$('vaultSeal');if(vaultSeal){vaultSeal.addEventListener('click',async function(){var vaultInput=$('vaultInput');var text=vaultInput?vaultInput.value||'':'';_uiEmit('vaultSealed',{text:text});if(_stateMachine)_stateMachine.sealVault();});}
     var vaultSkip=document.querySelector('.v-skip');if(vaultSkip){vaultSkip.addEventListener('click',function(){if(_stateMachine)_stateMachine.sealVault();});}
     var mirrorCont=$('mirrorCont');if(mirrorCont){mirrorCont.addEventListener('click',function(){_uiEmit('mirrorContinue',{});if(_stateMachine&&_stateMachine.mirrorContinue)_stateMachine.mirrorContinue();else if(_stateMachine)_stateMachine.advancePhase();});}
@@ -2560,7 +2560,7 @@ var SessionUI = (function() {
         var btn=$('bleBtn');if(btn)btn.click();
         // Re-arm fallback so the gate fires again if pairing is cancelled or fails
         if(_synthFallbackTimer)clearTimeout(_synthFallbackTimer);
-        _synthFallbackTimer=setTimeout(function(){if(!_baselineReady)_showSourceGate();},15000);
+        _synthFallbackTimer=setTimeout(function(){if(!_baselineReady&&(!_biometricBridge||_biometricBridge.getActiveSource(_boundUserId)!=='h10'))_showSourceGate();},15000);
       });
     }
     var sgCont=$('sgContinue');
@@ -2681,6 +2681,11 @@ var SessionUI = (function() {
       _sawH10=true;
       _setSrcBadge('h10');
       _hideSourceGate();
+      // Lever (a): a connected sensor means the synthetic-fallback gate must never
+      // fire. Cancel the 15s timer here, before the CASE branch — so CASE 2's
+      // mid-arrival force-restart (below) has no live timer to fire against the
+      // old or new arrival window (lever c). Intentionally NOT re-armed.
+      if(_synthFallbackTimer){clearTimeout(_synthFallbackTimer);_synthFallbackTimer=null;}
       var running=bio._isArrivalRunning(userId);
       var baseline=bio.getArrivalBaseline(userId);
       var currentSampleSource=bio._getArrivalSampleSource(userId);

--- a/public/index_v8_production.html
+++ b/public/index_v8_production.html
@@ -2490,7 +2490,7 @@ var SessionUI = (function() {
   var _stateMachine=null,_biometricBridge=null,_dialogueDelivery=null,_integration=null,_boundUserId=null,_bleButtonAvailable=false;
   var _baselineReady=false,_synthFallbackTimer=null;
   var _sawH10=false,_sawSynthetic=false,_explicitSyntheticOptIn=false,_continueClickCount=0;
-  function _enableTapButton(source){_baselineReady=true;if(_synthFallbackTimer){clearTimeout(_synthFallbackTimer);_synthFallbackTimer=null;}var tp=$('tapP');if(tp){tp.classList.remove('tap-disabled');}var sub=$('tapSub');if(sub){sub.textContent='Ready. Tap when you are.';}console.log('[UI] Session start button enabled — baseline:',source);}
+  function _enableTapButton(source){_baselineReady=true;if(_synthFallbackTimer){clearTimeout(_synthFallbackTimer);_synthFallbackTimer=null;}var tp=$('tapP');if(tp){tp.classList.remove('tap-disabled');}var sub=$('tapSub');if(sub){sub.textContent='Ready. Tap when you are.';}if(source==='h10')_hideSourceGate();console.log('[UI] Session start button enabled — baseline:',source);}
   function _updateTapSubtitle(text){var sub=$('tapSub');if(sub)sub.textContent=text;}
   function _initSrcBadge(){if($('srcBadge'))return;var b=document.createElement('div');b.id='srcBadge';b.className='src-hidden';b.innerHTML='<span class="src-pip"></span><span id="srcLbl">SYNTHETIC</span>';document.body.appendChild(b);}
   function _setSrcBadge(source){var b=$('srcBadge');if(!b)return;var lbl=$('srcLbl');if(source==='h10'){b.className='src-h10';if(lbl)lbl.textContent='H10 • LIVE';}else if(source==='synthetic'){b.className='src-synthetic';if(lbl)lbl.textContent='SYNTHETIC';}else{b.className='src-hidden';}}
@@ -2523,7 +2523,7 @@ var SessionUI = (function() {
     var tapP=$('tapP');if(tapP){tapP.addEventListener('click',async function(){if(tapP.classList.contains('tap-disabled'))return;if(_dialogueDelivery)await _dialogueDelivery.unlockAudio();if(_stateMachine)_stateMachine.advancePhase();});}
     // Source gate: at 15s without BLE pairing, show explicit choice overlay (no silent synthetic fallback)
     _initSrcBadge();
-    _synthFallbackTimer=setTimeout(function(){if(!_baselineReady)_showSourceGate();},15000);
+    _synthFallbackTimer=setTimeout(function(){if(!_baselineReady&&(!_biometricBridge||_biometricBridge.getActiveSource(_boundUserId)!=='h10'))_showSourceGate();},15000);
     var vaultSeal=$('vaultSeal');if(vaultSeal){vaultSeal.addEventListener('click',async function(){var vaultInput=$('vaultInput');var text=vaultInput?vaultInput.value||'':'';_uiEmit('vaultSealed',{text:text});if(_stateMachine)_stateMachine.sealVault();});}
     var vaultSkip=document.querySelector('.v-skip');if(vaultSkip){vaultSkip.addEventListener('click',function(){if(_stateMachine)_stateMachine.sealVault();});}
     var mirrorCont=$('mirrorCont');if(mirrorCont){mirrorCont.addEventListener('click',function(){_uiEmit('mirrorContinue',{});if(_stateMachine&&_stateMachine.mirrorContinue)_stateMachine.mirrorContinue();else if(_stateMachine)_stateMachine.advancePhase();});}
@@ -2560,7 +2560,7 @@ var SessionUI = (function() {
         var btn=$('bleBtn');if(btn)btn.click();
         // Re-arm fallback so the gate fires again if pairing is cancelled or fails
         if(_synthFallbackTimer)clearTimeout(_synthFallbackTimer);
-        _synthFallbackTimer=setTimeout(function(){if(!_baselineReady)_showSourceGate();},15000);
+        _synthFallbackTimer=setTimeout(function(){if(!_baselineReady&&(!_biometricBridge||_biometricBridge.getActiveSource(_boundUserId)!=='h10'))_showSourceGate();},15000);
       });
     }
     var sgCont=$('sgContinue');
@@ -2681,6 +2681,11 @@ var SessionUI = (function() {
       _sawH10=true;
       _setSrcBadge('h10');
       _hideSourceGate();
+      // Lever (a): a connected sensor means the synthetic-fallback gate must never
+      // fire. Cancel the 15s timer here, before the CASE branch — so CASE 2's
+      // mid-arrival force-restart (below) has no live timer to fire against the
+      // old or new arrival window (lever c). Intentionally NOT re-armed.
+      if(_synthFallbackTimer){clearTimeout(_synthFallbackTimer);_synthFallbackTimer=null;}
       var running=bio._isArrivalRunning(userId);
       var baseline=bio.getArrivalBaseline(userId);
       var currentSampleSource=bio._getArrivalSampleSource(userId);


### PR DESCRIPTION
…s the user

On a real non-replay H10 run the session could not leave arrival. The synthetic- fallback source gate (full-screen z1500 modal) fired on a 15s timer that checked only !_baselineReady, ignoring BLE state. Arrival always takes ~30s, so the gate fired every session; connecting H10 hid it momentarily but never cancelled the timer, and arrival completion never dismissed it — leaving the enabled tap button behind the modal. The only exits defeated H10 (disconnect the sensor, or opt into synthetic). Mid-arrival pairing (CASE 2 force-restart) compounded it.

Design intent: the gate exists ONLY to warn when there is no biometric source and we are about to use synthetic. H10 connected → gate must NEVER appear; a completed H10 baseline must dismiss it. Synthetic-only keeps its two-click opt-in (logged UX decision); a passive synthetic baseline does NOT auto-dismiss.

Three coherent levers (index_v8 dual-file, byte-identical cb38be6): (a) bleConnected cancels _synthFallbackTimer outright (before the CASE branch),
    so a connected sensor can never produce the gate — and CASE 2's mid-arrival
    restart has no live timer to fire against the old/new window (lever c,
    structural; intentionally not re-armed).
(b) _enableTapButton hides the gate only when the baseline source is 'h10';
    synthetic completion does not dismiss it (opt-in preserved).
(c) realized by (a)'s placement before the CASE branch. Trigger guard: both timer-arm sites now fire only if
    !_baselineReady && getActiveSource(_boundUserId) !== 'h10'
(safety net for a connect landing right at the 15s mark).

New trigger condition: gate appears only if, 15s after arrival began, there is no completed baseline AND no H10 sensor connected.

Verification (local server + Playwright):
- synthetic-only (real): gate at 16s; still up at 32s with tap enabled behind it (synthetic not auto-dismissed); two-click Continue dismisses + advances
- H10 paired @4s (stubbed BLE): gate never appears through 17s, activeSource h10
- gate-then-pair (stubbed BLE): gate up at 15.5s, hidden on connect, stays hidden (timer cancelled, no re-fire)
- nveC2Smoke.js regression: all pass No NVE module changes; arrival sample-count/timing constants untouched.